### PR TITLE
Add a string vector example for Chicken Scheme

### DIFF
--- a/return-string-vector/uname-chicken.scm
+++ b/return-string-vector/uname-chicken.scm
@@ -1,0 +1,30 @@
+(import (chicken foreign) (srfi 133))
+
+(foreign-declare "#include <sys/utsname.h>")
+
+; NOTE: There is probably a better way to do this
+(define uname
+  (foreign-primitive scheme-object () "
+    struct utsname buf;
+    C_word* ptr;
+    C_word vec;
+    if (uname(&buf) == 0) {
+        /* The entries in the `utsname` struct have an undefined length, but */
+        /* we need a length in order to allocate the right amount of data, so */
+        /* we'll go with 256. This is the value used internally on FreeBSD and */
+        /* macOS. */
+        ptr = C_alloc(C_SIZEOF_VECTOR(5) + 5 * C_SIZEOF_STRING(256));
+        vec = C_vector(&ptr, 5,
+                       C_string2(&ptr, buf.sysname),
+                       C_string2(&ptr, buf.nodename),
+                       C_string2(&ptr, buf.release),
+                       C_string2(&ptr, buf.version),
+                       C_string2(&ptr, buf.machine));
+    } else {
+        ptr = C_alloc(C_SIZEOF_VECTOR(0));
+        vec = C_vector(&ptr, 0);
+    }
+    C_return(vec);"))
+
+(vector-for-each (lambda (x) (display x) (newline))
+                 (uname))

--- a/return-string-vector/uname-chicken.sh
+++ b/return-string-vector/uname-chicken.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -eu
+cd "$(dirname "$0")"
+echo "Entering directory '$PWD'"
+set -x
+csc uname-chicken.scm
+./uname-chicken


### PR DESCRIPTION
Note that it requires the `srfi-133` egg, which is not installed by default nor is installing it handled by the included shell script. It's just a call to `chicken-install srfi-133` away though.