### PR TITLE
Use strlen() to find how much space needed

### DIFF
--- a/return-string-vector/uname-chicken.scm
+++ b/return-string-vector/uname-chicken.scm
@@ -2,18 +2,19 @@
 
 (foreign-declare "#include <sys/utsname.h>")
 
-; NOTE: There is probably a better way to do this
 (define uname
   (foreign-primitive scheme-object () "
     struct utsname buf;
     C_word* ptr;
     C_word vec;
     if (uname(&buf) == 0) {
-        /* The entries in the `utsname` struct have an undefined length, but */
-        /* we need a length in order to allocate the right amount of data, so */
-        /* we'll go with 256. This is the value used internally on FreeBSD and */
-        /* macOS. */
-        ptr = C_alloc(C_SIZEOF_VECTOR(5) + 5 * C_SIZEOF_STRING(256));
+        ptr = C_alloc(C_SIZEOF_VECTOR(5) +
+                      5 +  /* One null terminator for each string */
+                      strlen(buf.sysname) +
+                      strlen(buf.nodename) +
+                      strlen(buf.release) +
+                      strlen(buf.version) +
+                      strlen(buf.machine));
         vec = C_vector(&ptr, 5,
                        C_string2(&ptr, buf.sysname),
                        C_string2(&ptr, buf.nodename),


### PR DESCRIPTION
@ararslan This PR uses `strlen()` instead of the fixed length of 256 to how much space is needed for the `uname` strings. Do you think this is a valid approach?

Another alternative would be to use `sizeof(buf.sysname)`. [The POSIX specification of `struct utsname`](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_utsname.h.html) says that the fields are always `char []` arrays instead of `char *` pointers, so `sizeof` will get the precise size on each platform.

However, the strings are usually much shorter than that so `strlen()` will save space.