### PR TITLE
Ignore the executables produced by running Chicken examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.dylib
 *.o*
 *.so
+*-chicken


### PR DESCRIPTION
The shell scripts that run Chicken by invoking `csc` don't specify an output name, so it defaults to the input file name with .scm removed. Based on the naming convention set up in this repo, we can assume that all are named as `*-chicken`, and so we can ignore that pattern to avoid dirtying the repo state when compiling Chicken examples.