### PR TITLE
Ignore Windows-specific build products (.dll and .exe)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.dylib
 *.o*
 *.so
+*.dll
+*.exe


### PR DESCRIPTION
As noted by @johnwcowan in https://github.com/schemedoc/ffi-cookbook/pull/5#issuecomment-678476680.