### PR TITLE
Add example that passes a bytevector from Scheme to C

### DIFF
--- a/pass-bytevector/bytevector-gambit.scm
+++ b/pass-bytevector/bytevector-gambit.scm
@@ -1,0 +1,20 @@
+(c-declare "#include <string.h>")  ; For memchr()
+
+(define (disp . xs) (for-each display xs) (newline))
+
+(define (byte-after-first-null bytevector)
+  ((c-lambda (scheme-object size_t) scheme-object
+     "___U8 *bytes = ___CAST(___U8 *, ___BODY(___arg1));
+      size_t nbytes = ___arg2;
+      ___U8 *where = memchr(bytes, 0, nbytes);
+      if ((where != NULL) && (where < bytes + nbytes - 1))
+        ___return(___FIX(where[1]));
+      else
+        ___return(___FAL);")
+   bytevector
+   (bytevector-length bytevector)))
+
+(let ((bytes (make-bytevector 1024 1)))
+  (bytevector-u8-set! bytes 1000 0)
+  (bytevector-u8-set! bytes 1001 42)
+  (disp (byte-after-first-null bytes)))

--- a/pass-bytevector/bytevector-gambit.sh
+++ b/pass-bytevector/bytevector-gambit.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+cd "$(dirname "$0")"
+echo "Entering directory '$PWD'"
+set -x
+rm -f bytevector-gambit.o1
+gsc bytevector-gambit.scm
+gsi bytevector-gambit.o1


### PR DESCRIPTION
@ararslan Here's a Gambit example that passes a bytevector (aka u8vector) from Scheme to a C FFI function.

It passes a bytevector of length 1024 that is filled with 1 values (1 is an arbitrary nonzero value). However, we put a zero value at the (arbitrarily chosen) position 1000, and the nonzero value 42 at the next position 1001.

The FFI procedure `byte-after-first-null` takes a bytevector, finds the first null byte in it, and returns the value of the byte after that. In this example, it returns 42. The point is to demonstrate that the FFI can handle bytevectors with embedded null bytes. Passing bytevectors in Gambit needs to be done manually: we pass it as a generic `scheme-object` and unpack it in C. Strings are much easier to pass, but they are null-terminated so embedded null bytes would raise an exception.